### PR TITLE
Use inheritence for common properties of all Lookup commands?

### DIFF
--- a/src/main/java/me/mcofficer/james/commands/lookup/Lookup.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/Lookup.java
@@ -15,11 +15,11 @@ import java.util.List;
 public class Lookup extends ShowCommand {
 
     public Lookup(Lookups lookups) {
+        super(lookups);
         name = "lookup";
         help = "Outputs the image and description of <query>.";
         arguments = "<query>";
         category = James.lookup;
-        this.lookups = lookups;
     }
 
     protected void reply(DataNode node, CommandEvent event) {

--- a/src/main/java/me/mcofficer/james/commands/lookup/Lookup.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/Lookup.java
@@ -14,8 +14,6 @@ import java.util.List;
 
 public class Lookup extends ShowCommand {
 
-    private final Lookups lookups;
-
     public Lookup(Lookups lookups) {
         name = "lookup";
         help = "Outputs the image and description of <query>.";
@@ -24,19 +22,8 @@ public class Lookup extends ShowCommand {
         this.lookups = lookups;
     }
 
-    @Override
-    protected void execute(CommandEvent event) {
-        List<DataNode> matches = lookups.getNodesByString(event.getArgs());
-
-        if (matches.size() < 1)
-            event.reply("Found no matches for `" + event.getArgs() + "`!");
-        else if (matches.size() == 1)
-            event.reply(createLookupMessage(matches.get(0), event.getGuild()));
-        else
-            Util.displayNodeSearchResults(matches, event, (message, integer) -> event.reply(createLookupMessage(matches.get(integer - 1), event.getGuild())));
-    }
-
-    private MessageEmbed createLookupMessage(DataNode node, Guild guild) {
+    protected void reply(DataNode node, CommandEvent event) {
+        Guild guild = event.getGuild();
         EmbedBuilder embedBuilder = embedImageByNode(node, guild, lookups, true);
         String description = lookups.getDescription(node);
         
@@ -47,6 +34,6 @@ public class Lookup extends ShowCommand {
 
         embedBuilder.appendDescription("\n\n" + lookups.getLinks(node));
 
-        return embedBuilder.build();
+        event.reply(embedBuilder.build());
     }
 }

--- a/src/main/java/me/mcofficer/james/commands/lookup/Show.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/Show.java
@@ -16,11 +16,11 @@ import java.util.List;
 public class Show extends ShowCommand {
 
     public Show(Lookups lookups) {
+        super(lookups);
         name = "show";
         help = "Outputs the image and data associated with <query>.";
         arguments = "<query>";
         category = James.lookup;
-        this.lookups = lookups;
     }
 
     protected void reply(DataNode node, CommandEvent event) {

--- a/src/main/java/me/mcofficer/james/commands/lookup/Show.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/Show.java
@@ -15,8 +15,6 @@ import java.util.List;
 
 public class Show extends ShowCommand {
 
-    private final Lookups lookups;
-
     public Show(Lookups lookups) {
         name = "show";
         help = "Outputs the image and data associated with <query>.";
@@ -25,24 +23,12 @@ public class Show extends ShowCommand {
         this.lookups = lookups;
     }
 
-    @Override
-    protected void execute(CommandEvent event) {
-    List<DataNode> matches = lookups.getNodesByString(event.getArgs());
-
-    if (matches.size() < 1)
-        event.reply("Found no matches for `" + event.getArgs() + "`!");
-    else if (matches.size() == 1)
-        event.reply(createShowMessage(matches.get(0), event));
-    else
-        Util.displayNodeSearchResults(matches, event, (((message, integer) -> event.reply(createShowMessage(matches.get(integer - 1), event)))));
-    }
-
-    private Message createShowMessage(DataNode node, CommandEvent event) {
+    protected void reply(DataNode node, CommandEvent event) {
         Guild guild = event.getGuild();
         EmbedBuilder embedBuilder = embedImageByNode(node, guild, lookups, false);
-        return new MessageBuilder()
+        event.reply(new MessageBuilder()
                 .setEmbed(embedBuilder.isEmpty() ? null : embedBuilder.build()) // if no image was found, the embed builder cannot be built
                 .append(Util.sendInChunksReturnLast(event.getTextChannel(), lookups.getNodeAsText(node).split("(?=\n)")))
-                .build();
+                .build());
     }
 }

--- a/src/main/java/me/mcofficer/james/commands/lookup/ShowCommand.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/ShowCommand.java
@@ -15,7 +15,11 @@ import java.util.List;
 
 public abstract class ShowCommand extends Command {
 
-    protected Lookups lookups;
+    protected final Lookups lookups;
+    
+    public ShowCommand(Lookups lookups) {
+        this.lookups = lookups;
+    }
 
     @Override
     protected void execute(CommandEvent event) {

--- a/src/main/java/me/mcofficer/james/commands/lookup/ShowCommand.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/ShowCommand.java
@@ -18,6 +18,7 @@ public abstract class ShowCommand extends Command {
     protected final Lookups lookups;
     
     public ShowCommand(Lookups lookups) {
+        super();
         this.lookups = lookups;
     }
 

--- a/src/main/java/me/mcofficer/james/commands/lookup/ShowCommand.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/ShowCommand.java
@@ -15,6 +15,20 @@ import java.util.List;
 
 public abstract class ShowCommand extends Command {
 
+    protected Lookups lookups;
+
+    @Override
+    protected void execute(CommandEvent event) {
+        List<DataNode> matches = lookups.getNodesByString(event.getArgs());
+
+        if (matches.size() < 1)
+            event.reply("Found no matches for `" + event.getArgs() + "`!");
+        else if (matches.size() == 1)
+            reply(matches.get(0), event);
+        else
+            Util.displayNodeSearchResults(matches, event, ((message, integer) -> reply(matches.get(integer - 1), event)));
+    }
+
     protected EmbedBuilder embedImageByNode(DataNode node, Guild guild, Lookups lookups, boolean thumbnail) {
         String imageToEmbedUrl = lookups.getImageUrl(node, thumbnail);
         EmbedBuilder embedBuilder = new EmbedBuilder()
@@ -25,6 +39,7 @@ public abstract class ShowCommand extends Command {
             embedBuilder.setImage(imageToEmbedUrl);
         return embedBuilder;
     }
-
+    
+    protected abstract void reply(DataNode node, CommandEvent event);
 
 }

--- a/src/main/java/me/mcofficer/james/commands/lookup/Showdata.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/Showdata.java
@@ -23,16 +23,7 @@ public class Showdata extends ShowCommand {
         this.lookups = lookups;
     }
 
-    @Override
-    protected void execute(CommandEvent event) {
-        List<DataNode> matches = lookups.getNodesByString(event.getArgs());
-
-        if (matches.size() < 1)
-            event.reply("Found no matches for `" + event.getArgs() + "`!");
-        else if (matches.size() == 1)
-            Util.sendInChunks(event.getTextChannel(), lookups.getNodeAsText(matches.get(0)).split("(?=\n)"));
-        else
-            Util.displayNodeSearchResults(matches, event, ((message, integer) ->
-                    Util.sendInChunks(event.getTextChannel(), lookups.getNodeAsText(matches.get(integer - 1)).split("(?=\n)"))));
+    protected void reply(DataNode node, CommandEvent event) {
+        Util.sendInChunks(event.getTextChannel(), lookups.getNodeAsText(node).split("(?=\n)"));
     }
 }

--- a/src/main/java/me/mcofficer/james/commands/lookup/Showdata.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/Showdata.java
@@ -13,8 +13,6 @@ import java.util.List;
 
 public class Showdata extends ShowCommand {
 
-    private final Lookups lookups;
-
     public Showdata(Lookups lookups) {
         name = "showdata";
         help = "Outputs the data associated with <query>.";

--- a/src/main/java/me/mcofficer/james/commands/lookup/Showdata.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/Showdata.java
@@ -14,11 +14,11 @@ import java.util.List;
 public class Showdata extends ShowCommand {
 
     public Showdata(Lookups lookups) {
+        super(lookups);
         name = "showdata";
         help = "Outputs the data associated with <query>.";
         arguments = "<query>";
         category = James.lookup;
-        this.lookups = lookups;
     }
 
     protected void reply(DataNode node, CommandEvent event) {

--- a/src/main/java/me/mcofficer/james/commands/lookup/Showimage.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/Showimage.java
@@ -15,11 +15,11 @@ import java.util.List;
 public class Showimage extends ShowCommand {
 
     public Showimage(Lookups lookups) {
+        super(lookups);
         name = "showimage";
         help = "Outputs the image associated with <query>.";
         arguments = "<query>";
         category = James.lookup;
-        this.lookups = lookups;
     }
 
     protected void reply(DataNode node, CommandEvent event) {

--- a/src/main/java/me/mcofficer/james/commands/lookup/Showimage.java
+++ b/src/main/java/me/mcofficer/james/commands/lookup/Showimage.java
@@ -14,8 +14,6 @@ import java.util.List;
 
 public class Showimage extends ShowCommand {
 
-    private final Lookups lookups;
-
     public Showimage(Lookups lookups) {
         name = "showimage";
         help = "Outputs the image associated with <query>.";
@@ -24,19 +22,7 @@ public class Showimage extends ShowCommand {
         this.lookups = lookups;
     }
 
-    @Override
-    protected void execute(CommandEvent event) {
-        List<DataNode> matches = lookups.getNodesByString(event.getArgs());
-
-        if (matches.size() < 1)
-            event.reply("Found no matches for `" + event.getArgs() + "`!");
-        else if (matches.size() == 1)
-            event.reply(createShowimageMessage(matches.get(0), event.getGuild()));
-        else
-            Util.displayNodeSearchResults(matches, event, (message, integer) -> event.reply(createShowimageMessage(matches.get(integer - 1), event.getGuild())));
-    }
-
-    private MessageEmbed createShowimageMessage(DataNode node, Guild guild) {
-        return embedImageByNode(node, guild, lookups, false).build();
+    protected void reply(DataNode node, CommandEvent event) {
+        event.reply(embedImageByNode(node, event.getGuild(), lookups, false).build());
     }
 }


### PR DESCRIPTION
I think this is better than how it was before, it's at least fancier by using more polymorphism and other programming buzzwords.
This might also make it easier to move these commands to slash commands later on, maybe.