### PR TITLE
A few changes to the Audio classes

### DIFF
--- a/src/main/java/me/mcofficer/james/audio/Audio.java
+++ b/src/main/java/me/mcofficer/james/audio/Audio.java
@@ -90,14 +90,10 @@ public class Audio {
             }
 
             @Override
-            public void noMatches() {
-
-            }
+            public void noMatches() {}
 
             @Override
-            public void loadFailed(FriendlyException exception) {
-
-            }
+            public void loadFailed(FriendlyException exception) {}
         });
     }
 
@@ -123,14 +119,10 @@ public class Audio {
             }
 
             @Override
-            public void noMatches() {
-
-            }
+            public void noMatches() {}
 
             @Override
-            public void loadFailed(FriendlyException exception) {
-
-            }
+            public void loadFailed(FriendlyException exception) {}
         });
     }
 
@@ -250,7 +242,7 @@ public class Audio {
     }
 
     public void remove(CommandEvent event, int position) {
-        announceRemove(event, trackScheduler.remove(position == -1 ? trackScheduler.getQueueSize() : position));
+        announceRemove(event, trackScheduler.remove(position == -1 ? trackScheduler.getQueueSize() - 1 : position - 1));
     }
 
     private void announceRemove(@NotNull CommandEvent event, AudioTrack removed) {
@@ -267,7 +259,7 @@ public class Audio {
     }
 
     public void remove(SlashCommandEvent event, int position) {
-        announceRemove(event, trackScheduler.remove(position == -1 ? trackScheduler.getQueueSize() : position));
+        announceRemove(event, trackScheduler.remove(position == -1 ? trackScheduler.getQueueSize() - 1 : position - 1));
     }
 
     private void announceRemove(@NotNull SlashCommandEvent event, AudioTrack removed) {

--- a/src/main/java/me/mcofficer/james/audio/Playlists.java
+++ b/src/main/java/me/mcofficer/james/audio/Playlists.java
@@ -6,7 +6,6 @@ import org.json.JSONTokener;
 
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/main/java/me/mcofficer/james/audio/TrackScheduler.java
+++ b/src/main/java/me/mcofficer/james/audio/TrackScheduler.java
@@ -6,7 +6,6 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.CheckForNull;
 import java.util.Collections;
 import java.util.LinkedList;
 
@@ -37,10 +36,15 @@ public class TrackScheduler extends AudioEventAdapter {
         play(queue.poll());
     }
 
-    public AudioTrack remove(int position) {
-        if (position > getQueueSize())
+    /**
+     * Removes the track at the position given and returns it as an AudioTrack.
+     * @param index The index of the track in the queue to be removed.
+     * @return The track that was removed as an AudioTrack, or
+     */
+    public AudioTrack remove(int index) {
+        if (index >= getQueueSize() || index < 0)
             return null;
-        return queue.remove(position - 1);
+        return queue.remove(index);
     }
 
     /**
@@ -59,6 +63,12 @@ public class TrackScheduler extends AudioEventAdapter {
             queue.offer(track);
     }
 
+    /**
+     * Called when a track ends. If looping is on, plays the track that just ended, otherwise, calls skip().
+     * @param player The AudioPlayer object.
+     * @param track The track that just ended.
+     * @param endReason The reason the track ended.
+     */
     @Override
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
         if(endReason.mayStartNext) {
@@ -70,7 +80,7 @@ public class TrackScheduler extends AudioEventAdapter {
     }
 
     /**
-     * Stops Playback and clears the {@link #queue}.
+     * Stops Playback and clears the {@link #queue} and turns looping off.
      */
     public void stop() {
         player.stopTrack();


### PR DESCRIPTION
Changed the way TrackScheduler.remove() works so it takes an index in the array holding the queue instead of the number corresponding to where the song to be removed would appear in the queue embed and changed Audio.remove() accordingly.
TrackScheduler.remove() also now checks the passed value for being below zero (would produce an IndexOutOfBoundsException) as well as if it is greater than the highest index in the queue.
Also removed a couple of (apparently) unused imports.
Also removed some empty lines inside methods with no body in Audio.
Also added some comments.