### PR TITLE
Added a slash command for swizzleimage

### DIFF
--- a/src/main/java/me/mcofficer/james/James.java
+++ b/src/main/java/me/mcofficer/james/James.java
@@ -136,7 +136,7 @@ public class James {
         SlashCommand[] slashCommands = {
                 new Play(audio), new Stop(audio), new Loop(audio), new Skip(audio), new Remove(audio), new Shuffle(audio), new Current(audio),
                 new Pause(audio), new Unpause(audio), new Queue(audio), new Playlist(audio, playlists),
-                new Template(), new CRConvert(),
+                new SwizzleImage(), new Template(), new CRConvert(),
                 new Info(githubToken), new Ping(),
                 new Issue(), new Commit(), new Lookup(lookups), new Show(lookups), new Showdata(lookups), new Showimage(lookups), new Swizzle(lookups),
                 new Purge(), new Optin(optinRoles, timeoutRole), new Optout(optinRoles, timeoutRole),

--- a/src/main/java/me/mcofficer/james/commands/creatortools/SwizzleImage.java
+++ b/src/main/java/me/mcofficer/james/commands/creatortools/SwizzleImage.java
@@ -1,23 +1,82 @@
 package me.mcofficer.james.commands.creatortools;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import me.mcofficer.james.James;
+import me.mcofficer.james.JamesSlashCommand;
 import me.mcofficer.james.tools.ImageSwizzler;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
-public class SwizzleImage extends Command {
+public class SwizzleImage extends JamesSlashCommand {
 
     private final ImageSwizzler swizzler = new ImageSwizzler();
+    private final String optionNameSwizzleNumber = "swizzle";
 
     public SwizzleImage() {
+        super();
         name = "swizzleimage";
         help = "Applies the Swizzle X to the uploaded image[s]. If X is not defined, applies swizzles 1-6.";
         arguments = "[X] <attached images>";
         category = James.creatorTools;
+
+        List<OptionData> data = new ArrayList<>();
+        //OptionData swizzles = new OptionData(OptionType.INTEGER, optionNameSwizzleNumber, "The number of the swizzle to apply, leave blank to apply them all.", false);
+        //List<Command.Choice> swizzleChoices = new ArrayList<>();
+        //for (int i = 1; i <= 6; i++) {
+            //swizzleChoices.add(new Command.Choice(Integer.toString(i), i));
+        //}
+        //swizzles.addChoices(swizzleChoices);
+        //data.add(swizzles);
+        data.add(new OptionData(OptionType.STRING, optionNameSwizzleNumber, "The swizzle(s) to apply. Leave blank for all.", false));
+        this.options = data;
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        Member requester = event.getMember();
+
+        event.getChannel().getIterableHistory().takeAsync(1).thenAccept(latestMessage -> {
+            if (latestMessage.isEmpty()) {
+                return;
+            }
+            Message message = latestMessage.get(0);
+            if (message.getAuthor().getIdLong() != requester.getIdLong()) {
+                return;
+            }
+            OptionMapping option = event.getOption(optionNameSwizzleNumber);
+            swizzleImageHelper(message, event.getTextChannel(), option != null ? option.getAsString() : "");
+        });
+    }
+
+    private void swizzleImageHelper(Message messageToSwizzle, TextChannel channel, String args) {
+        List<Message.Attachment> attachments = messageToSwizzle.getAttachments();
+        if (attachments.isEmpty())
+            channel.sendMessage("Please attach one or more images.");
+        else
+            for (Message.Attachment a : attachments) {
+                if (a.getWidth() > 1000 || a.getHeight() > 1000) {
+                    channel.sendMessage(a.getFileName() + " is larger than 1000px.");
+                    continue;
+                }
+
+                a.retrieveInputStream().thenAccept(inputStream -> {
+                    try {
+                        channel.sendFile(swizzler.swizzle(inputStream, args), "swizzled.png").queue();
+                    }
+                    catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                });
+            }
     }
 
     @Override


### PR DESCRIPTION
Because we can't include attachments with slash commands, the slash command version of swizzleimage will expect the images to swizzle to be attached to the last message sent before the command was sent, that message will also need to be from the same user as the slash command.
There's a bunch of repeated code here for each version of the command that could be combined (doing so would slightly change the way the current version of the command works but not hugely) but I'd like comments on this implementation before doing that refactor, also, since the non-slash commands are being deprecated, it might be better to just wipe the old code when that happens.