### PR TITLE
Unix time command

### DIFF
--- a/src/main/java/me/mcofficer/james/James.java
+++ b/src/main/java/me/mcofficer/james/James.java
@@ -15,6 +15,7 @@ import me.mcofficer.james.commands.misc.Dog;
 import me.mcofficer.james.commands.info.*;
 import me.mcofficer.james.commands.lookup.*;
 import me.mcofficer.james.commands.misc.Translate;
+import me.mcofficer.james.commands.misc.UnixTime;
 import me.mcofficer.james.commands.moderation.*;
 import me.mcofficer.james.tools.Lookups;
 import me.mcofficer.james.tools.Translator;
@@ -114,7 +115,7 @@ public class James {
                 new Play(audio), new Stop(audio), new Loop(audio), new Skip(audio), new Remove(audio), new Shuffle(audio), new Current(audio),
                 new Pause(audio), new Unpause(audio), new Queue(audio), new Playlist(audio, playlists),
                 new SwizzleImage(), new Template(), new CRConvert(),
-                new Cat(), new Dog(), new Birb(), new Translate(new Translator(okHttpClient)),
+                new Cat(), new Dog(), new Birb(), new Translate(new Translator(okHttpClient)), new UnixTime(),
                 new Info(githubToken), new Ping(),
                 new Issue(), new Commit(), new Showdata(lookups), new Showimage(lookups), new Show(lookups), new Lookup(lookups), new Swizzle(lookups),
                 new Purge(), new Optin(optinRoles, cfg.getProperty("timeoutRole")), new Optout(optinRoles),

--- a/src/main/java/me/mcofficer/james/commands/misc/UnixTime.java
+++ b/src/main/java/me/mcofficer/james/commands/misc/UnixTime.java
@@ -1,0 +1,60 @@
+package me.mcofficer.james.commands.misc;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import me.mcofficer.james.James;
+
+public class UnixTime extends Command {
+
+    public UnixTime() {
+        name = "unix-time";
+        help = "Returns the unix time representation of the current time, or the time X units after this time. The unit for the time offset is given as a single, case-insensitive character: 'S' for seconds, 'M' for minutes, 'H' for hours, 'D' for days, 'W' for weeks.";
+		arguments = "[X [U]]";
+        category = James.misc;
+    }
+
+    @Override
+    protected void execute(CommandEvent event) {
+		long unixTime = event.getMessage().getTimeCreated().toEpochSecond();
+		unixTime += GetOffset(event);
+		event.reply(Long.toString(unixTime));
+    }
+
+	private static long GetOffset(CommandEvent event) {
+		String argString = event.getArgs();
+		if(argString.isEmpty())
+			return 0;
+		String[] args = argString.split(" ");
+		long offset = 0;
+        try {
+            offset = Long.parseLong(args[0]);
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            event.reply("Failed to parse \"" + args[1] + "\" as Long!");
+            return 0;
+        }
+		if(args.length > 1)
+			return offset * GetMultiplier(args[1]);
+		return offset;
+	}
+
+	private static int GetMultiplier(String multiplierString) {
+		if(multiplierString.isEmpty())
+			return 1;
+		char multiplier = multiplierString.toUpperCase().charAt(0);
+		switch (multiplier) {
+			case 'S':
+				return 1;
+			case 'M':
+				return 60;
+			case 'H':
+				return 60 * 60;
+			case 'D':
+				return 24 * 60 * 60;
+			case 'W':
+				return 7 * 24 * 60 * 60;
+			default:
+				return 1;
+		}
+	}
+}

--- a/src/main/java/me/mcofficer/james/commands/misc/UnixTime.java
+++ b/src/main/java/me/mcofficer/james/commands/misc/UnixTime.java
@@ -9,23 +9,23 @@ public class UnixTime extends Command {
     public UnixTime() {
         name = "unix-time";
         help = "Returns the unix time representation of the current time, or the time X units after this time. The unit for the time offset is given as a single, case-insensitive character: 'S' for seconds, 'M' for minutes, 'H' for hours, 'D' for days, 'W' for weeks.";
-		arguments = "[X [U]]";
+        arguments = "[X [U]]";
         category = James.misc;
     }
 
     @Override
     protected void execute(CommandEvent event) {
-		long unixTime = event.getMessage().getTimeCreated().toEpochSecond();
-		unixTime += GetOffset(event);
-		event.reply(Long.toString(unixTime));
+        long unixTime = event.getMessage().getTimeCreated().toEpochSecond();
+        unixTime += GetOffset(event);
+        event.reply(Long.toString(unixTime));
     }
 
-	private static long GetOffset(CommandEvent event) {
-		String argString = event.getArgs();
-		if(argString.isEmpty())
-			return 0;
-		String[] args = argString.split(" ");
-		long offset = 0;
+    private static long GetOffset(CommandEvent event) {
+        String argString = event.getArgs();
+        if(argString.isEmpty())
+            return 0;
+        String[] args = argString.split(" ");
+        long offset = 0;
         try {
             offset = Long.parseLong(args[0]);
         } catch (NumberFormatException e) {
@@ -33,28 +33,28 @@ public class UnixTime extends Command {
             event.reply("Failed to parse \"" + args[1] + "\" as Long!");
             return 0;
         }
-		if(args.length > 1)
-			return offset * GetMultiplier(args[1]);
-		return offset;
-	}
+        if(args.length > 1)
+            return offset * GetMultiplier(args[1]);
+        return offset;
+    }
 
-	private static int GetMultiplier(String multiplierString) {
-		if(multiplierString.isEmpty())
-			return 1;
-		char multiplier = multiplierString.toUpperCase().charAt(0);
-		switch (multiplier) {
-			case 'S':
-				return 1;
-			case 'M':
-				return 60;
-			case 'H':
-				return 60 * 60;
-			case 'D':
-				return 24 * 60 * 60;
-			case 'W':
-				return 7 * 24 * 60 * 60;
-			default:
-				return 1;
-		}
-	}
+    private static int GetMultiplier(String multiplierString) {
+        if(multiplierString.isEmpty())
+            return 1;
+        char multiplier = multiplierString.toUpperCase().charAt(0);
+        switch (multiplier) {
+            case 'S':
+                return 1;
+            case 'M':
+                return 60;
+            case 'H':
+                return 60 * 60;
+            case 'D':
+                return 24 * 60 * 60;
+            case 'W':
+                return 7 * 24 * 60 * 60;
+            default:
+                return 1;
+        }
+    }
 }


### PR DESCRIPTION
Adds a command for getting the current time (or, a time some point in the future) in the unix time format.
The idea is to make it easier to get values to put into Discord timestamps, rather than needing to go find a website that'll do it.
```
-unix-time
```
Gives the current time in unix time format.

```
-unix-time X
```
Gives the time X seconds after now in unix time format.

```
-unix-time X U
```
Gives the time X units after now in unix time format.
The unit is given by the second, case-insensitive argument:
`s` - seconds
`m` - minutes
`h` - hours
`d` - days
`w` - weeks
